### PR TITLE
Update kat.py

### DIFF
--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -239,7 +239,7 @@ class KATProvider(generic.TorrentProvider):
                             id = item['guid']
                             title = item['title']
                             url = item['torrent_magneturi']
-                            verified = bool(item['torrent_verified'] or 0)
+                            verified = bool(int(item['torrent_verified']) or 0)
                             seeders = int(item['torrent_seeds'])
                             leechers = int(item['torrent_peers'])
                             size = int(item['torrent_contentlength'])


### PR DESCRIPTION
Cast the string item['torrent_verified'] as an integer so that 'verified' will be False if the returned string is "0" which would otherwise be True because it is non-empty.